### PR TITLE
Micro.blog custom CSS, footer, JS

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,8 +19,8 @@
     {{ partial "footer.html" . }}
     {{ partial "custom_footer.html" . }}
 
-		{{ range .Site.Params.plugins_js }}
-			<script src="{{ . }}"></script>
-		{{ end }}
+    {{ range .Site.Params.plugins_js }}
+      <script src="{{ . }}"></script>
+    {{ end }}
   </body>
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,5 +17,10 @@
     <main class="main">{{ block "main" . }}{{ end }}</main>
 
     {{ partial "footer.html" . }}
+    {{ partial "custom_footer.html" . }}
+
+		{{ range .Site.Params.plugins_js }}
+			<script src="{{ . }}"></script>
+		{{ end }}
   </body>
 </html>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,6 +25,8 @@
 
   {{ if and .IsPage (not site.Params.disableHLJS) }}
   <link rel="preload stylesheet" as="style" href="{{ `an-old-hope.min.css` | absURL }}" />
+  <link rel="stylesheet" href="{{ "custom.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
+  
   <script
     defer
     src="{{ `highlight.min.js` | absURL }}"

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"title": "Paper theme",
 	"description": "A simple, clean, flexible Hugo theme, customized for Micro.blog."
 }


### PR DESCRIPTION
Added references to the special custom.css and custom_footer.html templates that Micro.blog uses. Increased the plug-in version number too, although feel free to manage that yourself. Thanks!